### PR TITLE
fix: Preserve returned value from spawned command

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { join, resolve, sep } = require('path');
 
 parseArgs()
 	.then(state => requireFiles(state))
-	.then(state => spawnNextCommand(state))
+	.then(state => process.exitCode = spawnNextCommand(state).status)
 ;
 
 async function parseArgs() {
@@ -73,7 +73,7 @@ function safeRequire(ref) {
 }
 
 function spawnNextCommand({ nextCommand, nextCommandArgs, env }) {
-	spawn(nextCommand, nextCommandArgs, {
+	return spawn.sync(nextCommand, nextCommandArgs, {
 		stdio: 'inherit',
 		env,
 	});


### PR DESCRIPTION
The intent here is to make `dynenv` return the same value as the command it spawned, to prevent false positives if used in part of a CI/CD process. To wit, this makes `dynenv false ; echo $?` return `1` instead of `0`.

Not sure of plans for future directions for `dynenv` but note that this does switch to a synchronous spawn to capture the return value.
